### PR TITLE
feat(accounts): implement system admin management and setup flow

### DIFF
--- a/lib/fusion_flow/accounts.ex
+++ b/lib/fusion_flow/accounts.ex
@@ -99,6 +99,27 @@ defmodule FusionFlow.Accounts do
     |> Repo.insert!()
   end
 
+  @doc """
+  Returns whether at least one user is a system admin.
+  Used to decide whether to show the setup page or normal login.
+  """
+  def has_system_admin? do
+    import Ecto.Query
+    Repo.exists?(from u in User, where: u.is_system_admin == true)
+  end
+
+  @doc """
+  Registers the first user as system admin (used by the setup flow).
+  """
+  def register_system_admin(attrs) do
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> User.password_changeset(attrs)
+    |> User.confirm_changeset()
+    |> User.admin_changeset(%{is_system_admin: true})
+    |> Repo.insert()
+  end
+
   ## Settings
 
   @doc """
@@ -173,6 +194,20 @@ defmodule FusionFlow.Accounts do
   def update_user_username(user, attrs) do
     user
     |> User.registration_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Updates user attributes allowed only for admins (e.g. is_system_admin).
+
+  ## Example
+
+      iex> update_user(user, %{is_system_admin: true})
+      {:ok, %User{}}
+  """
+  def update_user(user, attrs) do
+    user
+    |> User.admin_changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/fusion_flow/accounts/user.ex
+++ b/lib/fusion_flow/accounts/user.ex
@@ -9,6 +9,7 @@ defmodule FusionFlow.Accounts.User do
     field :hashed_password, :string, redact: true
     field :confirmed_at, :utc_datetime
     field :authenticated_at, :utc_datetime, virtual: true
+    field :is_system_admin, :boolean, default: false
 
     timestamps(type: :utc_datetime)
   end
@@ -124,6 +125,14 @@ defmodule FusionFlow.Accounts.User do
   end
 
   @doc """
+  Changeset for updating user attributes that only admins may set (e.g. is_system_admin).
+  """
+  def admin_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:is_system_admin])
+  end
+
+  @doc """
   Confirms the account by setting `confirmed_at`.
   """
   def confirm_changeset(user) do
@@ -146,4 +155,10 @@ defmodule FusionFlow.Accounts.User do
     Pbkdf2.no_user_verify()
     false
   end
+
+  @doc """
+  Returns whether the user is a system admin.
+  """
+  def system_admin?(%__MODULE__{is_system_admin: value}), do: value == true
+  def system_admin?(_), do: false
 end

--- a/lib/fusion_flow_web/live/user_live/setup.ex
+++ b/lib/fusion_flow_web/live/user_live/setup.ex
@@ -1,0 +1,111 @@
+defmodule FusionFlowWeb.UserLive.Setup do
+  use FusionFlowWeb, :live_view
+
+  alias FusionFlow.Accounts
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if Accounts.has_system_admin?() do
+      {:ok,
+       socket
+       |> put_flash(:info, gettext("Setup already completed. Please log in."))
+       |> redirect(to: ~p"/users/log-in")}
+    else
+      form =
+        %FusionFlow.Accounts.User{}
+        |> FusionFlow.Accounts.User.registration_changeset(%{})
+        |> FusionFlow.Accounts.User.password_changeset(%{})
+        |> to_form(as: "user")
+
+      {:ok,
+       socket
+       |> assign(:page_title, gettext("Setup"))
+       |> assign(:form, form)}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-[80vh] flex flex-col items-center justify-center p-4">
+      <div class="w-full max-w-md bg-white dark:bg-slate-800 p-8 rounded-3xl shadow-2xl border border-gray-100 dark:border-slate-700/50">
+        <div class="text-center mb-8">
+          <h1 class="text-3xl font-extrabold text-gray-900 dark:text-white tracking-tight">
+            {gettext("Setup FusionFlow")}
+          </h1>
+
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            {gettext("Create the first administrator account to get started.")}
+          </p>
+        </div>
+
+        <.form
+          for={@form}
+          id="setup_form"
+          phx-submit="save"
+          class="space-y-5"
+        >
+          <.input
+            field={@form[:username]}
+            type="text"
+            label={gettext("Username")}
+            placeholder={gettext("Enter your username")}
+            required
+            phx-mounted={JS.focus()}
+          />
+          <.input
+            field={@form[:email]}
+            type="email"
+            label={gettext("Email")}
+            placeholder={gettext("Enter your email")}
+            required
+          />
+          <.input
+            field={@form[:password]}
+            type="password"
+            label={gettext("Password")}
+            placeholder="••••••••"
+            required
+          />
+          <.input
+            field={@form[:password_confirmation]}
+            type="password"
+            label={gettext("Confirm password")}
+            placeholder="••••••••"
+            required
+          />
+          <div class="pt-2">
+            <.button
+              type="submit"
+              variant="primary"
+              class="w-full py-4 text-base font-bold shadow-lg shadow-indigo-500/25 transition-all hover:shadow-indigo-500/40 active:scale-[0.98]"
+            >
+              {gettext("Create account")}
+            </.button>
+          </div>
+        </.form>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("save", %{"user" => user_params}, socket) do
+    case Accounts.register_system_admin(user_params) do
+      {:ok, _user} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Account created successfully. You can now log in."))
+         |> redirect(to: ~p"/users/log-in")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        form =
+          changeset
+          |> to_form(as: "user")
+
+        {:noreply,
+         socket
+         |> assign(:form, form)}
+    end
+  end
+end

--- a/lib/fusion_flow_web/router.ex
+++ b/lib/fusion_flow_web/router.ex
@@ -11,6 +11,7 @@ defmodule FusionFlowWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_scope_for_user
+    plug :redirect_to_setup_if_no_admin
     plug FusionFlowWeb.Plugs.SetLocale
   end
 
@@ -63,6 +64,7 @@ defmodule FusionFlowWeb.Router do
 
     live_session :current_user,
       on_mount: [{FusionFlowWeb.UserAuth, :mount_current_scope}] do
+      live "/setup", UserLive.Setup, :new
       live "/users/log-in", UserLive.Login, :new
     end
 

--- a/lib/fusion_flow_web/user_auth.ex
+++ b/lib/fusion_flow_web/user_auth.ex
@@ -223,10 +223,17 @@ defmodule FusionFlowWeb.UserAuth do
     if socket.assigns.current_scope && socket.assigns.current_scope.user do
       {:cont, socket}
     else
+      {redirect_to, flash_type, flash_msg} =
+        if Accounts.has_system_admin?() do
+          {~p"/users/log-in", :error, gettext("You must log in to access this page.")}
+        else
+          {~p"/setup", :info, gettext("Create the first administrator account to get started.")}
+        end
+
       socket =
         socket
-        |> Phoenix.LiveView.put_flash(:error, gettext("You must log in to access this page."))
-        |> Phoenix.LiveView.redirect(to: ~p"/users/log-in")
+        |> Phoenix.LiveView.put_flash(flash_type, flash_msg)
+        |> Phoenix.LiveView.redirect(to: redirect_to)
 
       {:halt, socket}
     end
@@ -271,16 +278,43 @@ defmodule FusionFlowWeb.UserAuth do
 
   @doc """
   Plug for routes that require the user to be authenticated.
+  When no user is logged in, redirects to /setup if there is no system admin yet.
   """
   def require_authenticated_user(conn, _opts) do
     if conn.assigns.current_scope && conn.assigns.current_scope.user do
       conn
     else
+      if Accounts.has_system_admin?() do
+        conn
+        |> put_flash(:error, gettext("You must log in to access this page."))
+        |> maybe_store_return_to()
+        |> redirect(to: ~p"/users/log-in")
+        |> halt()
+      else
+        conn
+        |> redirect(to: ~p"/setup")
+        |> halt()
+      end
+    end
+  end
+
+  @doc """
+  Plug that redirects to /setup when there is no system admin.
+  Only the /setup path is allowed when no admin exists.
+  """
+  def redirect_to_setup_if_no_admin(conn, _opts) do
+    path = conn.request_path
+
+    if path == "/setup" do
       conn
-      |> put_flash(:error, gettext("You must log in to access this page."))
-      |> maybe_store_return_to()
-      |> redirect(to: ~p"/users/log-in")
-      |> halt()
+    else
+      if Accounts.has_system_admin?() do
+        conn
+      else
+        conn
+        |> redirect(to: ~p"/setup")
+        |> halt()
+      end
     end
   end
 

--- a/priv/repo/migrations/20260221120000_add_is_system_admin_to_users.exs
+++ b/priv/repo/migrations/20260221120000_add_is_system_admin_to_users.exs
@@ -1,0 +1,9 @@
+defmodule FusionFlow.Repo.Migrations.AddIsSystemAdminToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :is_system_admin, :boolean, default: false, null: false
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,17 +9,3 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`)
 # and so on) as they will fail if something goes wrong.
-
-# Seed Admin User
-admin_email = "admin@admin.com"
-admin_password = "admin"
-
-if user = FusionFlow.Accounts.get_user_by_email(admin_email) do
-  FusionFlow.Repo.delete!(user)
-end
-
-FusionFlow.Accounts.register_user!(%{
-  email: admin_email,
-  username: "admin",
-  password: admin_password
-})


### PR DESCRIPTION
- Added functionality to check for system admin existence and redirect users accordingly.
- Introduced methods for registering a system admin and updating user attributes restricted to admins.
- Created a setup LiveView for the initial admin account creation.
- Updated user schema to include `is_system_admin` field and corresponding changeset.
- Modified router and user authentication logic to support new setup flow.