### PR TITLE
feat: add api key permission toggle

### DIFF
--- a/apps/fusion_flow_ui/assets/js/app.js
+++ b/apps/fusion_flow_ui/assets/js/app.js
@@ -200,6 +200,23 @@ const hooks = {
     updated() {
       this.el.focus();
     }
+  },
+  ApiKeyScopeToggle: {
+    mounted() {
+      this.el.addEventListener("click", () => {
+        const form = this.el.closest("form");
+        const selector = this.el.dataset.scopeSelector;
+        if (!form || !selector) return;
+
+        const scopes = Array.from(form.querySelectorAll(selector));
+        const shouldCheck = scopes.some((scope) => !scope.checked);
+
+        scopes.forEach((scope) => {
+          scope.checked = shouldCheck;
+          scope.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+      });
+    }
   }
 }
 

--- a/apps/fusion_flow_ui/lib/fusion_flow_ui/live/api_key_live.ex
+++ b/apps/fusion_flow_ui/lib/fusion_flow_ui/live/api_key_live.ex
@@ -137,9 +137,21 @@ defmodule FusionFlowUI.ApiKeyLive do
             />
 
             <fieldset class="space-y-3">
-              <legend class="text-sm font-medium text-gray-900 dark:text-white">
-                {gettext("Scopes")}
-              </legend>
+              <div class="flex items-center justify-between gap-3">
+                <legend class="text-sm font-medium text-gray-900 dark:text-white">
+                  {gettext("Scopes")}
+                </legend>
+                <button
+                  id="api-key-scope-toggle"
+                  type="button"
+                  phx-hook="ApiKeyScopeToggle"
+                  data-scope-selector="input[name='api_key[scopes][]']"
+                  class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-gray-300 dark:hover:border-indigo-800 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-300"
+                >
+                  <.icon name="hero-check-circle" class="h-4 w-4" />
+                  {gettext("Toggle all")}
+                </button>
+              </div>
               <div class="grid gap-2">
                 <label
                   :for={scope <- @scopes}

--- a/apps/fusion_flow_ui/test/fusion_flow_ui/fusion_flow_web/live/api_key_live_test.exs
+++ b/apps/fusion_flow_ui/test/fusion_flow_ui/fusion_flow_web/live/api_key_live_test.exs
@@ -22,7 +22,7 @@ defmodule FusionFlowUI.ApiKeyLiveTest do
     test "renders API key management for system admin", %{conn: conn} do
       admin = system_admin_fixture()
 
-      {:ok, _lv, html} =
+      {:ok, lv, html} =
         conn
         |> log_in_user(admin)
         |> live(~p"/api-keys")
@@ -31,6 +31,11 @@ defmodule FusionFlowUI.ApiKeyLiveTest do
       assert html =~ "Create key"
       assert html =~ "Existing keys"
       assert html =~ "System admins only"
+      assert has_element?(lv, "#api-key-scope-toggle", "Toggle all")
+
+      for scope <- ApiKey.scopes() do
+        assert has_element?(lv, "input[name='api_key[scopes][]'][value='#{scope}']")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Add a Toggle all button to the API key scopes UI
- Wire a LiveView JS hook to check/uncheck all scope checkboxes
- Add LiveView coverage for the rendered toggle and permission inputs

## Verification
- mix test apps/fusion_flow_ui/test/fusion_flow_ui/fusion_flow_web/live/api_key_live_test.exs
- mix precommit
- mix assets.build