### PR TITLE
Refactor: extract shared AI chat logic into FusionFlowUI.AIChat

### DIFF
--- a/apps/fusion_flow_ui/lib/fusion_flow_ui/ai_chat.ex
+++ b/apps/fusion_flow_ui/lib/fusion_flow_ui/ai_chat.ex
@@ -1,0 +1,205 @@
+defmodule FusionFlowUI.AIChat do
+  @moduledoc """
+  Shared helpers for the AI chat experiences (`FlowLive` and `FlowAiCreatorLive`).
+
+  Centralizes the logic that used to be duplicated across both LiveViews:
+
+    * converting the in-memory `{:user | :ai, text}` message list into the
+      `%{role: ..., content: ...}` shape the agents expect;
+    * consuming an agent stream while forwarding chunks/errors to the LiveView;
+    * appending a streamed chunk to the running assistant message;
+    * extracting the `create_flow` JSON out of an assistant reply; and
+    * normalizing the AI-generated nodes into the single canonical shape the
+      Rete editor consumes (whether pushed to the client or persisted first).
+  """
+
+  @node_default_x 100
+  @node_default_y 100
+  @node_x_spacing 500
+
+  @output_default_code "ui do\n  text :status, label: \"Final Status\", default: \"success\"\nend\n"
+
+  @doc """
+  Converts the chat message list into the agent message format.
+
+  Drops the trailing element, which is always the empty `{:ai, ""}` placeholder
+  appended right before a request is sent.
+  """
+  def to_api_messages(messages) do
+    messages
+    |> Enum.map(fn
+      {:user, text} -> %{role: "user", content: text}
+      {:ai, text} -> %{role: "assistant", content: text}
+    end)
+    |> List.delete_at(-1)
+  end
+
+  @doc """
+  Consumes an agent stream, forwarding events to `parent`.
+
+  Sends `{:chat_stream_chunk, text}` for each text delta and
+  `{:chat_stream_error, reason}` on error. Returns the fully accumulated reply
+  as a binary, or `{:error, reason}` if the stream errored.
+  """
+  def consume_stream(stream, parent) do
+    Enum.reduce_while(stream, "", fn
+      {:text_delta, text}, acc ->
+        send(parent, {:chat_stream_chunk, text})
+        {:cont, acc <> text}
+
+      {:error, reason}, _acc ->
+        send(parent, {:chat_stream_error, reason})
+        {:halt, {:error, reason}}
+
+      {:finish, _reason}, acc ->
+        {:cont, acc}
+
+      _other, acc ->
+        {:cont, acc}
+    end)
+  end
+
+  @doc """
+  Appends a streamed `chunk` to the last assistant message, if there is one.
+  """
+  def append_chunk(messages, chunk) do
+    case List.last(messages) do
+      {:ai, last_content} -> List.replace_at(messages, -1, {:ai, last_content <> chunk})
+      _ -> messages
+    end
+  end
+
+  @doc """
+  Returns the map of node definitions (`name => definition`) used by the Rete
+  editor when loading graph data.
+  """
+  def node_definitions do
+    FusionFlowNodes.Nodes.all_nodes()
+    |> Map.new(fn node -> {node.name, node} end)
+  end
+
+  @doc """
+  Extracts a `create_flow` payload from an assistant reply.
+
+  Handles both a reply that is pure JSON (optionally fenced with ```json) and a
+  reply where the JSON is embedded in surrounding prose. Returns `{:ok, json}`
+  only when the decoded payload is a `create_flow` action, otherwise `:error`.
+  """
+  def extract_create_flow_json(content) when is_binary(content) do
+    case decode_create_flow(strip_code_fence(content)) do
+      {:ok, json} ->
+        {:ok, json}
+
+      :error ->
+        case Regex.run(~r/\{[\s\S]*"action":\s*"create_flow"[\s\S]*\}/m, content) do
+          [candidate] -> decode_create_flow(candidate)
+          _ -> :error
+        end
+    end
+  end
+
+  @doc """
+  Normalizes AI-generated nodes into the canonical shape the Rete editor expects.
+
+  Reconciles the two previously divergent implementations: flattens `{value: ...}`
+  controls, applies the `Evaluate Code` and `Output` control defaults, fills in
+  `id/name/type/label/inputs/outputs`, and lays the nodes out horizontally.
+  """
+  def normalize_nodes(raw_nodes) when is_list(raw_nodes) do
+    raw_nodes
+    |> Enum.map(&normalize_node/1)
+    |> reposition_horizontally()
+  end
+
+  defp normalize_node(node) do
+    data = node["data"] || %{}
+    name = node["name"]
+    type = node["type"] || name
+    label = node["label"] || data["label"] || name
+
+    position = node["position"] || %{"x" => data["x"] || 0, "y" => data["y"] || 0}
+
+    controls =
+      node
+      |> base_controls(data)
+      |> flatten_control_values()
+      |> normalize_controls_for(type, name)
+
+    %{
+      "id" => node["id"],
+      "name" => name,
+      "type" => type,
+      "label" => label,
+      "position" => position,
+      "controls" => controls,
+      "inputs" => node["inputs"] || %{},
+      "outputs" => node["outputs"] || %{}
+    }
+  end
+
+  defp base_controls(node, data) do
+    cond do
+      is_map(node["controls"]) and node["controls"] != %{} -> node["controls"]
+      is_map(data["controls"]) and data["controls"] != %{} -> data["controls"]
+      true -> Map.drop(data, ["label", "x", "y", "controls"])
+    end
+  end
+
+  defp flatten_control_values(controls) do
+    Map.new(controls, fn {key, value} ->
+      if is_map(value) and Map.has_key?(value, "value") do
+        {key, value["value"]}
+      else
+        {key, value}
+      end
+    end)
+  end
+
+  defp normalize_controls_for(controls, type, name) do
+    cond do
+      "Evaluate Code" in [type, name] ->
+        code_value = controls["code"] || controls["code_elixir"] || ""
+
+        controls
+        |> Map.put("code_elixir", code_value)
+        |> Map.put_new("code_python", "")
+        |> Map.put_new("language", "elixir")
+        |> Map.delete("code")
+
+      "Output" in [type, name] ->
+        controls
+        |> Map.put_new("status", "success")
+        |> Map.put_new("code", @output_default_code)
+
+      true ->
+        controls
+    end
+  end
+
+  defp reposition_horizontally(nodes) do
+    nodes
+    |> Enum.with_index()
+    |> Enum.map(fn {node, index} ->
+      current_y = get_in(node, ["position", "y"]) || @node_default_y
+
+      Map.put(node, "position", %{
+        "x" => @node_default_x + index * @node_x_spacing,
+        "y" => current_y
+      })
+    end)
+  end
+
+  defp strip_code_fence(content) do
+    content
+    |> String.replace(~r/^```json\s*/, "")
+    |> String.replace(~r/\s*```$/, "")
+    |> String.trim()
+  end
+
+  defp decode_create_flow(string) do
+    case Jason.decode(string) do
+      {:ok, %{"action" => "create_flow"} = json} -> {:ok, json}
+      _ -> :error
+    end
+  end
+end

--- a/apps/fusion_flow_ui/lib/fusion_flow_ui/live/flow_ai_creator_live.ex
+++ b/apps/fusion_flow_ui/lib/fusion_flow_ui/live/flow_ai_creator_live.ex
@@ -3,6 +3,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
 
   alias FusionFlowCore.Flows
   alias FusionFlowAI.Agents.FlowPlanner
+  alias FusionFlowUI.AIChat
 
   @impl true
   def mount(_params, _session, socket) do
@@ -38,13 +39,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
       {:noreply, socket}
     else
       messages = socket.assigns.messages ++ [{:user, content}, {:ai, ""}]
-
-      ai_messages =
-        Enum.map(messages, fn
-          {:user, text} -> %{role: "user", content: text}
-          {:ai, text} -> %{role: "assistant", content: text}
-        end)
-        |> List.delete_at(-1)
+      ai_messages = AIChat.to_api_messages(messages)
 
       socket =
         assign(socket,
@@ -60,26 +55,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
       socket =
         start_async(socket, :ai_stream, fn ->
           {:ok, result} = FlowPlanner.chat(ai_messages, nil, locale)
-
-          Enum.reduce_while(result.stream, :ok, fn event, _acc ->
-            case event do
-              {:text_delta, text} ->
-                send(parent, {:chat_stream_chunk, text})
-                {:cont, :ok}
-
-              {:error, reason} ->
-                send(parent, {:chat_stream_error, reason})
-                {:halt, {:error, reason}}
-
-              {:finish, _reason} ->
-                {:cont, :ok}
-
-              _ ->
-                {:cont, :ok}
-            end
-          end)
-
-          :ok
+          AIChat.consume_stream(result.stream, parent)
         end)
 
       {:noreply, socket}
@@ -90,13 +66,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
   def handle_event("approve_plan", _params, socket) do
     content = "Looks good! Please generate the final flow JSON now."
     messages = socket.assigns.messages ++ [{:user, content}, {:ai, ""}]
-
-    ai_messages =
-      Enum.map(messages, fn
-        {:user, text} -> %{role: "user", content: text}
-        {:ai, text} -> %{role: "assistant", content: text}
-      end)
-      |> List.delete_at(-1)
+    ai_messages = AIChat.to_api_messages(messages)
 
     socket = assign(socket, messages: messages, loading: true, ai_awaiting_approval: false)
     parent = self()
@@ -105,20 +75,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
     socket =
       start_async(socket, :ai_stream_json, fn ->
         {:ok, result} = FlowPlanner.chat(ai_messages, nil, locale)
-
-        full_reply =
-          Enum.reduce_while(result.stream, "", fn event, acc ->
-            case event do
-              {:text_delta, text} ->
-                send(parent, {:chat_stream_chunk, text})
-                {:cont, acc <> text}
-
-              _ ->
-                {:cont, acc}
-            end
-          end)
-
-        {:ok, full_reply}
+        AIChat.consume_stream(result.stream, parent)
       end)
 
     {:noreply, socket}
@@ -126,10 +83,7 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
 
   @impl true
   def handle_info({:chat_stream_chunk, text}, socket) do
-    messages = socket.assigns.messages
-    {_last_role, last_content} = List.last(messages)
-    updated_messages = List.replace_at(messages, -1, {:ai, last_content <> text})
-    {:noreply, assign(socket, messages: updated_messages)}
+    {:noreply, assign(socket, messages: AIChat.append_chunk(socket.assigns.messages, text))}
   end
 
   @impl true
@@ -150,9 +104,12 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
   end
 
   @impl true
-  def handle_async(:ai_stream_json, {:ok, {:ok, full_reply}}, socket) do
-    socket = parse_and_create_flow_if_json(full_reply, socket)
-    {:noreply, socket}
+  def handle_async(:ai_stream_json, {:ok, full_reply}, socket) when is_binary(full_reply) do
+    {:noreply, parse_and_create_flow_if_json(full_reply, socket)}
+  end
+
+  def handle_async(:ai_stream_json, {:ok, _other}, socket) do
+    {:noreply, assign(socket, loading: false)}
   end
 
   @impl true
@@ -161,66 +118,29 @@ defmodule FusionFlowUI.FlowAiCreatorLive do
   end
 
   defp parse_and_create_flow_if_json(content, socket) do
-    case Regex.run(~r/\{[\s\S]*"action":\s*"create_flow"[\s\S]*\}/m, content) do
-      [json_candidate] ->
-        case Jason.decode(json_candidate) do
-          {:ok, json_data} ->
-            flow_name = "AI Generated Flow #{System.unique_integer([:positive])}"
+    case AIChat.extract_create_flow_json(content) do
+      {:ok, json_data} ->
+        create_attrs = %{
+          name: "AI Generated Flow #{System.unique_integer([:positive])}",
+          nodes: AIChat.normalize_nodes(Map.get(json_data, "nodes", [])),
+          connections: Map.get(json_data, "connections", [])
+        }
 
-            # Normalize nodes to ensure compatibility with Rete.js editor
-            nodes =
-              json_data
-              |> Map.get("nodes", [])
-              |> Enum.map(fn node ->
-                node
-                |> Map.put_new("type", Map.get(node, "name"))
-                |> Map.update("controls", %{}, fn controls ->
-                  case Map.get(node, "type") || Map.get(node, "name") do
-                    "Evaluate Code" ->
-                      controls
-                      |> Map.put_new("language", "elixir")
-                      |> Map.put_new("code_elixir", Map.get(controls, "code", ""))
-                      |> Map.put_new("code_python", "")
-
-                    "Output" ->
-                      controls
-                      |> Map.put_new("status", "success")
-                      |> Map.put_new(
-                        "code",
-                        "ui do\n  text :status, label: \"Final Status\", default: \"success\"\nend\n"
-                      )
-
-                    _ ->
-                      controls
-                  end
-                end)
-              end)
-
-            create_attrs = %{
-              name: flow_name,
-              nodes: nodes,
-              connections: Map.get(json_data, "connections", [])
-            }
-
-            case Flows.create_flow(socket.assigns.current_scope, create_attrs) do
-              {:ok, new_flow} ->
-                socket
-                |> put_flash(:info, gettext("Flow built successfully!"))
-                |> push_navigate(to: ~p"/flows/#{new_flow}")
-
-              {:error, _} ->
-                assign(socket,
-                  messages:
-                    socket.assigns.messages ++ [{:error, "Failed to persist flow in database"}],
-                  loading: false
-                )
-            end
+        case Flows.create_flow(socket.assigns.current_scope, create_attrs) do
+          {:ok, new_flow} ->
+            socket
+            |> put_flash(:info, gettext("Flow built successfully!"))
+            |> push_navigate(to: ~p"/flows/#{new_flow}")
 
           {:error, _} ->
-            handle_regular_message(content, socket)
+            assign(socket,
+              messages:
+                socket.assigns.messages ++ [{:error, "Failed to persist flow in database"}],
+              loading: false
+            )
         end
 
-      nil ->
+      :error ->
         handle_regular_message(content, socket)
     end
   end

--- a/apps/fusion_flow_ui/lib/fusion_flow_ui/live/flow_live.ex
+++ b/apps/fusion_flow_ui/lib/fusion_flow_ui/live/flow_live.ex
@@ -1,6 +1,8 @@
 defmodule FusionFlowUI.FlowLive do
   use FusionFlowUI, :live_view
 
+  alias FusionFlowUI.AIChat
+
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     flow = FusionFlowCore.Flows.get_flow!(socket.assigns.current_scope, id)
@@ -64,17 +66,11 @@ defmodule FusionFlowUI.FlowLive do
     nodes = flow.nodes || []
     connections = flow.connections || []
 
-    all_definitions =
-      FusionFlowNodes.Nodes.all_nodes()
-      |> Enum.reduce(%{}, fn node, acc ->
-        Map.put(acc, node.name, node)
-      end)
-
     {:noreply,
      push_event(socket, "load_graph_data", %{
        nodes: nodes,
        connections: connections,
-       definitions: all_definitions
+       definitions: AIChat.node_definitions()
      })}
   end
 
@@ -266,16 +262,8 @@ defmodule FusionFlowUI.FlowLive do
     if content == "" do
       {:noreply, socket}
     else
-      messages = socket.assigns.chat_messages ++ [{:user, content}]
-      messages = messages ++ [{:ai, ""}]
-
-      ai_messages =
-        Enum.map(messages, fn
-          {:user, text} -> %{role: "user", content: text}
-          {:ai, text} -> %{role: "assistant", content: text}
-        end)
-
-      ai_messages = List.delete_at(ai_messages, -1)
+      messages = socket.assigns.chat_messages ++ [{:user, content}, {:ai, ""}]
+      ai_messages = AIChat.to_api_messages(messages)
 
       socket = assign(socket, chat_messages: messages, chat_loading: true)
 
@@ -285,26 +273,7 @@ defmodule FusionFlowUI.FlowLive do
       socket =
         start_async(socket, :ai_stream, fn ->
           {:ok, result} = FusionFlowAI.Agents.FlowCreator.chat(ai_messages, current_flow)
-
-          Enum.reduce_while(result.stream, :ok, fn event, _acc ->
-            case event do
-              {:text_delta, text} ->
-                send(parent, {:chat_stream_chunk, text})
-                {:cont, :ok}
-
-              {:error, reason} ->
-                send(parent, {:chat_stream_error, reason})
-                {:halt, {:error, reason}}
-
-              {:finish, _reason} ->
-                {:cont, :ok}
-
-              _ ->
-                {:cont, :ok}
-            end
-          end)
-
-          :ok
+          AIChat.consume_stream(result.stream, parent)
         end)
 
       {:noreply, socket}
@@ -721,111 +690,10 @@ defmodule FusionFlowUI.FlowLive do
 
   @impl true
   def handle_async(:ai_stream, {:ok, _result}, socket) do
-    messages = socket.assigns.chat_messages
-    {role, content} = List.last(messages)
-
     socket =
-      if role == :ai do
-        json_content =
-          content
-          |> String.replace(~r/^```json\s*/, "")
-          |> String.replace(~r/\s*```$/, "")
-          |> String.trim()
-
-        case Jason.decode(json_content) do
-          {:ok, %{"action" => "create_flow", "nodes" => raw_nodes, "connections" => connections}} ->
-            nodes =
-              Enum.map(raw_nodes, fn node ->
-                data = node["data"] || %{}
-
-                label = node["label"] || data["label"] || node["name"]
-
-                position =
-                  node["position"] ||
-                    %{"x" => data["x"] || 0, "y" => data["y"] || 0}
-
-                controls =
-                  cond do
-                    is_map(node["controls"]) and node["controls"] != %{} ->
-                      node["controls"]
-
-                    is_map(data["controls"]) and data["controls"] != %{} ->
-                      data["controls"]
-
-                    true ->
-                      Map.drop(data, ["label", "x", "y", "controls"])
-                  end
-
-                controls =
-                  Enum.into(controls, %{}, fn {k, v} ->
-                    if is_map(v) and Map.has_key?(v, "value") do
-                      {k, v["value"]}
-                    else
-                      {k, v}
-                    end
-                  end)
-
-                controls =
-                  if node["type"] == "Evaluate Code" or node["name"] == "Evaluate Code" do
-                    code_val = controls["code"] || controls["code_elixir"]
-
-                    if code_val do
-                      controls
-                      |> Map.put("code_elixir", code_val)
-                      |> Map.delete("code")
-                    else
-                      controls
-                    end
-                  else
-                    controls
-                  end
-
-                %{
-                  "id" => node["id"],
-                  "name" => node["name"],
-                  "type" => node["type"] || node["name"],
-                  "label" => label,
-                  "position" => position,
-                  "controls" => controls,
-                  "inputs" => node["inputs"] || %{},
-                  "outputs" => node["outputs"] || %{}
-                }
-              end)
-              |> Enum.with_index()
-              |> Enum.map(fn {node, index} ->
-                current_y = get_in(node, ["position", "y"]) || 100
-                new_x = 100 + index * 500
-
-                Map.put(node, "position", %{"x" => new_x, "y" => current_y})
-              end)
-
-            all_definitions =
-              FusionFlowNodes.Nodes.all_nodes()
-              |> Enum.reduce(%{}, fn node, acc ->
-                Map.put(acc, node.name, node)
-              end)
-
-            socket
-            |> push_event("load_graph_data", %{
-              nodes: nodes,
-              connections: connections,
-              definitions: all_definitions
-            })
-            |> put_flash(:info, "Flow generated by AI applied successfully!")
-            |> assign(has_changes: true)
-            |> update(:chat_messages, fn messages ->
-              List.replace_at(
-                messages,
-                -1,
-                {:ai, "Flow created successfully! You can see it on the canvas."}
-              )
-            end)
-
-          _ ->
-            socket
-        end
-      else
-        socket
+      case List.last(socket.assigns.chat_messages) do
+        {:ai, content} -> apply_ai_flow(socket, content)
+        _ -> socket
       end
 
     {:noreply, assign(socket, chat_loading: false)}
@@ -926,17 +794,8 @@ defmodule FusionFlowUI.FlowLive do
 
   @impl true
   def handle_info({:chat_stream_chunk, chunk}, socket) do
-    messages = socket.assigns.chat_messages
-    {last_role, last_content} = List.last(messages)
-
-    updated_messages =
-      if last_role == :ai do
-        List.replace_at(messages, -1, {:ai, last_content <> chunk})
-      else
-        messages
-      end
-
-    {:noreply, assign(socket, chat_messages: updated_messages)}
+    {:noreply,
+     assign(socket, chat_messages: AIChat.append_chunk(socket.assigns.chat_messages, chunk))}
   end
 
   @impl true
@@ -1108,6 +967,30 @@ defmodule FusionFlowUI.FlowLive do
       />
     </div>
     """
+  end
+
+  defp apply_ai_flow(socket, content) do
+    case AIChat.extract_create_flow_json(content) do
+      {:ok, %{"nodes" => raw_nodes} = json} ->
+        socket
+        |> push_event("load_graph_data", %{
+          nodes: AIChat.normalize_nodes(raw_nodes),
+          connections: Map.get(json, "connections", []),
+          definitions: AIChat.node_definitions()
+        })
+        |> put_flash(:info, "Flow generated by AI applied successfully!")
+        |> assign(has_changes: true)
+        |> update(:chat_messages, fn messages ->
+          List.replace_at(
+            messages,
+            -1,
+            {:ai, "Flow created successfully! You can see it on the canvas."}
+          )
+        end)
+
+      _ ->
+        socket
+    end
   end
 
   defp filter_nodes(query) do

--- a/apps/fusion_flow_ui/test/fusion_flow_ui/ai_chat_test.exs
+++ b/apps/fusion_flow_ui/test/fusion_flow_ui/ai_chat_test.exs
@@ -1,0 +1,133 @@
+defmodule FusionFlowUI.AIChatTest do
+  use ExUnit.Case, async: true
+
+  alias FusionFlowUI.AIChat
+
+  describe "to_api_messages/1" do
+    test "maps roles and drops the trailing assistant placeholder" do
+      messages = [{:user, "hi"}, {:ai, "hello"}, {:user, "again"}, {:ai, ""}]
+
+      assert AIChat.to_api_messages(messages) == [
+               %{role: "user", content: "hi"},
+               %{role: "assistant", content: "hello"},
+               %{role: "user", content: "again"}
+             ]
+    end
+  end
+
+  describe "append_chunk/2" do
+    test "appends to the last assistant message" do
+      messages = [{:user, "hi"}, {:ai, "par"}]
+
+      assert AIChat.append_chunk(messages, "tial") == [{:user, "hi"}, {:ai, "partial"}]
+    end
+
+    test "leaves messages untouched when the last is not an assistant message" do
+      messages = [{:ai, "done"}, {:user, "hi"}]
+
+      assert AIChat.append_chunk(messages, "x") == messages
+    end
+  end
+
+  describe "consume_stream/2" do
+    test "forwards text deltas and returns the accumulated reply" do
+      stream = [{:text_delta, "He"}, {:text_delta, "llo"}, {:finish, :stop}]
+
+      assert AIChat.consume_stream(stream, self()) == "Hello"
+      assert_received {:chat_stream_chunk, "He"}
+      assert_received {:chat_stream_chunk, "llo"}
+    end
+
+    test "forwards and returns an error, halting the stream" do
+      stream = [{:text_delta, "He"}, {:error, :boom}, {:text_delta, "never"}]
+
+      assert AIChat.consume_stream(stream, self()) == {:error, :boom}
+      assert_received {:chat_stream_chunk, "He"}
+      assert_received {:chat_stream_error, :boom}
+      refute_received {:chat_stream_chunk, "never"}
+    end
+  end
+
+  describe "extract_create_flow_json/1" do
+    test "parses a fenced JSON reply" do
+      content = "```json\n{\"action\": \"create_flow\", \"nodes\": []}\n```"
+
+      assert {:ok, %{"action" => "create_flow", "nodes" => []}} =
+               AIChat.extract_create_flow_json(content)
+    end
+
+    test "parses JSON embedded in surrounding prose" do
+      content =
+        ~s(Sure! Here it is: {"action": "create_flow", "nodes": [], "connections": []} done)
+
+      assert {:ok, %{"action" => "create_flow"}} = AIChat.extract_create_flow_json(content)
+    end
+
+    test "returns :error for non create_flow content" do
+      assert :error = AIChat.extract_create_flow_json("just a normal reply")
+      assert :error = AIChat.extract_create_flow_json(~s({"action": "something_else"}))
+    end
+  end
+
+  describe "normalize_nodes/1" do
+    test "fills defaults, flattens control values and lays nodes out horizontally" do
+      raw = [
+        %{"id" => "a", "name" => "Webhook", "controls" => %{"path" => %{"value" => "/in"}}},
+        %{"id" => "b", "name" => "Log"}
+      ]
+
+      assert [first, second] = AIChat.normalize_nodes(raw)
+
+      assert first["id"] == "a"
+      assert first["type"] == "Webhook"
+      assert first["label"] == "Webhook"
+      # control value maps are flattened to their raw value
+      assert first["controls"] == %{"path" => "/in"}
+      assert first["inputs"] == %{}
+      assert first["outputs"] == %{}
+      # x comes from the layout; y defaults to 0 when the node carries no position
+      assert first["position"] == %{"x" => 100, "y" => 0}
+
+      # second node is shifted to the right
+      assert second["position"]["x"] == 600
+    end
+
+    test "normalizes Evaluate Code controls" do
+      raw = [%{"id" => "a", "name" => "Evaluate Code", "controls" => %{"code" => "1 + 1"}}]
+
+      assert [node] = AIChat.normalize_nodes(raw)
+
+      assert node["controls"]["code_elixir"] == "1 + 1"
+      assert node["controls"]["code_python"] == ""
+      assert node["controls"]["language"] == "elixir"
+      refute Map.has_key?(node["controls"], "code")
+    end
+
+    test "normalizes Output controls with defaults" do
+      raw = [%{"id" => "a", "name" => "Output", "controls" => %{}}]
+
+      assert [node] = AIChat.normalize_nodes(raw)
+
+      assert node["controls"]["status"] == "success"
+      assert node["controls"]["code"] =~ "ui do"
+    end
+
+    test "reads label/position/controls from a nested data map" do
+      raw = [
+        %{
+          "id" => "a",
+          "name" => "Log",
+          "data" => %{"label" => "My Log", "x" => 5, "y" => 9, "level" => "info"}
+        }
+      ]
+
+      assert [node] = AIChat.normalize_nodes(raw)
+
+      assert node["label"] == "My Log"
+      # controls fall back to the data map (minus reserved keys)
+      assert node["controls"] == %{"level" => "info"}
+      # y is preserved from data, x is recomputed by the layout
+      assert node["position"] == %{"x" => 100, "y" => 9}
+    end
+  end
+end


### PR DESCRIPTION
Refactor: extract shared AI chat logic into FusionFlowUI.AIChat

Removes the AI chat logic that was duplicated across FlowLive and FlowAiCreatorLive, moving it into a single shared module (FusionFlowUI.AIChat): message conversion, stream consumption, create_flow JSON extraction, and node normalization.

Behavior change: the two node-normalization paths had drifted apart. FlowLive only handled Evaluate Code and repositioned nodes; FlowAiCreator handled Evaluate Code + Output but persisted a thinner shape. They're now reconciled into one normalize_nodes/1, so the AI-creator path also produces the full Rete node shape and horizontal layout.

Adds AIChatTest (12 tests); full fusion_flow_ui suite green (186 tests).